### PR TITLE
fix: Added code instructions for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,39 @@
 # BTS_Spy
 
-Training Project to scrape some information on training site [books.toscrape.com](http://books.toscrape.com)
+Training Project to scrape some information on training site [books.toscrape.com](http://books.toscrape.com).
 
-Part of [Open Classrooms](/https://openclassrooms.com) "DA Python" formation, 2nd Project
+Part of [Open Classrooms](/https://openclassrooms.com) "DA Python" formation, 2nd Project.
 
-It's better to have Python > 3.2.2 for decent html.parser
+It's better to have Python > 3.2.2 for decent html.parser.
 
 ## Creating Virtual environment, downloading and running the program
 
 Open a terminal and navigate into the folder you want BTS-Spy to be downloaded, and run the following commands:
 
+* On linux:
 ```
 git clone https://github.com/YoannDeb/BTS_Spy.git
 cd BTS_Spy
-Python -m venv env
+python3 -m venv env
 source env/bin/activate
 pip install -r requirements.txt
-Python BTS_Spy.py
+python BTS_Spy.py
+```
+
+* On Windows:
+```
+git clone https://github.com/YoannDeb/BTS_Spy.git
+cd BTS_Spy
+python -m venv env
+env\Scripts\activate.bat
+pip install -r requirements.txt
+python BTS_Spy.py
 ```
 
 ## What is this program doing?
 ### Information retrieving:
 
-It will generate one csv file by category, whose name is "category_url_name".csv, in a folder /data  
+It will generate one csv file by category, whose name is "category_url_name".csv, in a folder /data.
 
 The separator in the csv file is ",".
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -9,20 +9,32 @@ Il est préférable d'avoir une version Python > 3.2.2 pour avoir un module html
 ## Création de l'environnement virtuel, téléchargement et execution du programme
 
 Ouvrir un terminal, se placer dans le dossier voulu et lancer les commandes suivantes :
+
+* Sur linux:
 ```
 git clone https://github.com/YoannDeb/BTS_Spy.git
 cd BTS_Spy
-Python -m venv env
+python3 -m venv env
 source env/bin/activate
 pip install -r requirements.txt
-Python BTS_Spy.py
+python BTS_Spy.py
+```
+
+* Sur Windows:
+```
+git clone https://github.com/YoannDeb/BTS_Spy.git
+cd BTS_Spy
+python -m venv env
+env\Scripts\activate.bat
+pip install -r requirements.txt
+python BTS_Spy.py
 ```
 
 ## Que fait ce programme ?
 ### Récupération d'informations :
 
 Le programme va générer un fichier csv par catégorie, dans un dossier /data.
-Le nom de ce fichier sera "nom_de_la_categorie_dans_url".csv
+Le nom de ce fichier sera "nom_de_la_categorie_dans_url".csv.
 
 Le séparateur csv est ",".
 


### PR DESCRIPTION
In README.md there are now two command line instructions, one for linux and one for windows